### PR TITLE
12 dockerfile für backend

### DIFF
--- a/Backend/.dockerignore
+++ b/Backend/.dockerignore
@@ -1,0 +1,37 @@
+# Development files
+.env
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.coverage
+.mypy_cache/
+.ruff_cache/
+
+# Documentation and configuration
+README.md
+CLAUDE.md
+.vscode/
+.git/
+.gitignore
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE files
+.idea/
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+logs/

--- a/Backend/DOCKERFILE
+++ b/Backend/DOCKERFILE
@@ -1,0 +1,45 @@
+# Use Python 3.12 slim image for smaller size
+FROM python:3.12-slim
+
+# Install system dependencies (curl for health checks)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install UV (pinned version for reproducibility)
+RUN pip install --no-cache-dir uv==0.4.18
+
+# Create non-root user for security (using higher IDs to avoid host conflicts)
+RUN groupadd --gid 10001 appuser && \
+    useradd --uid 10001 --gid 10001 --create-home appuser
+
+# Switch to non-root user
+USER appuser
+
+# Set working directory
+WORKDIR /app
+
+# Set environment variables for optimization and configuration
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_NO_CACHE=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PROJECT_ENVIRONMENT=/app/.venv \
+    HOST=0.0.0.0 \
+    CONTAINER_PORT=5689
+
+# Copy UV configuration files first (for better layer caching)
+COPY --chown=appuser:appuser src/pyproject.toml src/uv.lock* ./
+
+# Install only production dependencies
+RUN uv sync --frozen --no-dev
+
+# Copy only necessary application files
+COPY --chown=appuser:appuser src/*.py ./
+
+# Expose the port the app runs on
+EXPOSE 5689
+
+# Run the application with graceful shutdown configuration
+CMD uv run uvicorn main:app --host $HOST --port $CONTAINER_PORT --timeout-keep-alive 120 --timeout-graceful-shutdown 30

--- a/Backend/src/.env.example
+++ b/Backend/src/.env.example
@@ -1,9 +1,0 @@
-# Application Configuration
-APP_NAME=Backend API
-APP_VERSION=0.1.0
-DEBUG=false
-LOG_LEVEL=INFO
-
-# Ollama Configuration (optional - uncomment to enable ollama)
-# OLLAMA__URL=http://localhost:11434
-# OLLAMA__MODEL=llama3.2

--- a/Backend/src/main.py
+++ b/Backend/src/main.py
@@ -1,5 +1,6 @@
 """FastAPI application entry point."""
 
+import sys
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -7,17 +8,21 @@ from loguru import logger
 from routes import router
 from settings import settings
 
+# Configure loguru logger
+logger.remove()  # Remove default handler
+logger.add(sys.stderr, level=settings.log_level.upper())
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan manager."""
-    logger.info("Starting up {}", settings.app_name)
+    logger.info("Starting up {}", settings.APP_NAME)
     yield
-    logger.info("Shutting down {}", settings.app_name)
+    logger.info("Shutting down {}", settings.APP_NAME)
 
 # Create FastAPI application
 app = FastAPI(
-    title=settings.app_name,
-    version=settings.app_version,
+    title=settings.APP_NAME,
+    version=settings.APP_VERSION,
     debug=settings.debug,
     lifespan=lifespan,
 )

--- a/Backend/src/routes.py
+++ b/Backend/src/routes.py
@@ -15,5 +15,5 @@ async def health_check() -> HealthResponse:
 
     return HealthResponse(
         status="healthy",
-        message=f"{settings.app_name} v{settings.app_version} is running"
+        message=f"{settings.APP_NAME} v{settings.APP_VERSION} is running"
     )

--- a/Backend/src/settings.py
+++ b/Backend/src/settings.py
@@ -13,7 +13,7 @@ class OllamaSettings(BaseModel):
 
 
 class Settings(BaseSettings):
-    """Application settings loaded from environment variables."""
+    """Application settings loaded from .env file and environment variables."""
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -22,19 +22,19 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    # API Configuration
-    app_name: str = Field(default="Backend API", description="Application name")
-    app_version: str = Field(default="0.0.0", description="Application version")
+    # Static application configuration (not configurable)
+    APP_NAME: str = "Backend API"
+    APP_VERSION: str = "0.1.0"
+
+    # Configurable settings
     debug: bool = Field(default=False, description="Enable debug mode")
+    log_level: str = Field(default="INFO", description="Logging level")
 
     # Ollama Configuration
     ollama: Optional[OllamaSettings] = Field(
         default=None,
         description="Ollama configuration"
     )
-
-    # Logging Configuration
-    log_level: str = Field(default="INFO", description="Logging level")
 
 
 # Global settings instance


### PR DESCRIPTION
This pullrequest adds a dockerfile for the python backend.
The resutlting image hast 5689 as the default port. 
The following env variables can be set.
HOST: host to use for the app (default: 0.0.0.0)
PORT: port to use for the app in the container (default:5689)
DEBUG: whether the app should run in debug mode (default: False)
LOGLEVEL: loglevel of the application (default: INFO)
OLLAMA__URL: (optional) address of ollama to use
OLLAMA__MODEL: (optional) model to use for ollama

Example command to run:
Podman:
cd Backend && podman build -f DOCKERFILE -t backend-app . && podman run -d -p 5689:9125 -e HOST=localhost -e 
PORT=9125 -e DEBUG=False -e LOGLEVEL=INFO --name backend-container backend-app

Docker.
cd Backend && docker build -f DOCKERFILE -t backend-app . && docker run -d -p 5689:9125 -e HOST=localhost -e PORT=9125 -e DEBUG=False -e LOGLEVEL=INFO --name backend-container backend-app

Closing #12 