### PR TITLE
Adds ollama to compose

### DIFF
--- a/Ollama/Dockerfile
+++ b/Ollama/Dockerfile
@@ -1,0 +1,8 @@
+FROM ollama/ollama:latest
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Ollama/entrypoint.sh
+++ b/Ollama/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# Start the Ollama server in the background
+echo "Starting Ollama server..."
+/bin/ollama serve &
+OLLAMA_PID=$!
+
+# Wait for the Ollama server to be accessible via its API
+echo "Waiting for Ollama API to be ready..."
+until curl -s http://localhost:11434 > /dev/null; do
+  sleep 1
+done
+
+# Pull the Mistral model
+echo "✅ Ollama is ready. Pulling mistral:latest model..."
+ollama pull mistral:latest
+
+echo "🟢 Model pull complete. Ollama service is operational."
+
+# Wait indefinitely for the background Ollama process (pid) to finish
+# This keeps the container running until stopped externally
+wait $OLLAMA_PID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ networks:
       driver: bridge
 
 volumes:
-    db_volume:
+  db_volume:
+  ollama_volume:
 
 services:
   frontend:
@@ -84,3 +85,14 @@ services:
     - ORACLE_PWD=password
     - SCHEMA_USER=app
     - SCHEMA_PASSWORD=apppassword
+
+  ollama:
+    build:
+      context: ./Ollama
+      dockerfile: Dockerfile
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_volume:/root/.ollama
+    networks:
+      - network


### PR DESCRIPTION
Ist erreichbar über localhost:11434.
Das Image verwendet ein entrypoints script, welches immer mistral:latest pullt, falls das aktuellste nicht vorhanden ist.
Beispiel:
curl -X POST http://localhost:11434/api/generate -d '{
  "model": "mistral",
  "prompt": "Explain sentiment analysis in one sentence.",
  "stream": false
}'